### PR TITLE
Updated xccdf gen-map command

### DIFF
--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
* Updated `abide xccdf gen-map` command to accept multiple XCCDF files at once
* Mapping files generated by `gen-map` now add a key called `benchmark` which give the benchmark title and version the mapping was generated from.