### PR TITLE
Fix duplicated parent-key-prefix

### DIFF
--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end

--- a/lib/abide_dev_utils/xccdf.rb
+++ b/lib/abide_dev_utils/xccdf.rb
@@ -291,7 +291,7 @@ module AbideDevUtils
         end
 
         c_map['benchmark'] = { 'title' => title, 'version' => version }
-        mappings = [framework, index, key_prefix]
+        mappings = [framework, index]
         mappings.unshift(key_prefix) unless key_prefix.empty?
         { mappings.join('::') => c_map }.to_yaml
       end


### PR DESCRIPTION
Fix parent-key-prefix erroneously being added to the and of the mapping.  

```
---
cem_linux::mappings::cis::title::cem_linux::mappings:
  level_1:
    server:
      Audit SGID executables:
      - 6.1.14
      -       - audit_sgid_executables
      -       - c6_1_14
      -       Audit SUID executables:
```
Was being produced instead of the correct:
```
---
cem_linux::mappings::cis::title:
  level_1:
    server:
      Audit SGID executables:
      - 6.1.14
      -       - audit_sgid_executables
      -       - c6_1_14
      -       Audit SUID executables:
```