### PR TITLE
(CEM-223) Abide dev utils crash with jira-ruby 2.1.5

### DIFF
--- a/abide_dev_utils.gemspec
+++ b/abide_dev_utils.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.11'
   spec.add_dependency 'cmdparse', '~> 3.0'
   spec.add_dependency 'puppet', '>= 6.23'
-  spec.add_dependency 'jira-ruby', '~> 2.1'
+  spec.add_dependency 'jira-ruby', '~> 2.2'
   spec.add_dependency 'ruby-progressbar', '~> 1.11'
   spec.add_dependency 'selenium-webdriver', '~> 4.0.0.beta4'
   spec.add_dependency 'google-cloud-storage', '~> 1.34'

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end


### PR DESCRIPTION
Pin jira-ruby to 2.2.x.  The latest version of jira-ruby 2.1.x (2.1.5) causes abide to crash.