### PR TITLE
(CEM-225) Fix facter_platform function to default to product's name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.9.3)
+    abide_dev_utils (0.9.5)
       cmdparse (~> 3.0)
       google-cloud-storage (~> 1.34)
       hashdiff (~> 1.0)
-      jira-ruby (~> 2.1)
+      jira-ruby (~> 2.2)
       nokogiri (~> 1.11)
       puppet (>= 6.23)
       ruby-progressbar (~> 1.11)
@@ -93,7 +93,7 @@ GEM
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
-    google-apis-core (0.4.1)
+    google-apis-core (0.4.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -170,7 +170,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puppet (7.13.1)
+    puppet (7.14.0)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)

--- a/lib/abide_dev_utils/xccdf.rb
+++ b/lib/abide_dev_utils/xccdf.rb
@@ -298,7 +298,16 @@ module AbideDevUtils
 
       def facter_platform
         cpe = xpath('xccdf:Benchmark/xccdf:platform')[0]['idref'].split(':')
-        [cpe[4].split('_')[0], cpe[5].split('.')[0]]
+        if cpe.length > 4
+          product_name = cpe[4].split('_')
+          product_version = cpe[5].split('.') unless cpe[5].nil?
+          return [product_name[0], product_version[0]] unless product_version[0] == '-'
+
+          return [product_name[0], product_name[-1]] if product_version[0] == '-'
+        end
+
+        product = cpe[3].split('_')
+        [product[0], product[-1]] # This should wrap the name i.e 'Windows' and the version '10'
       end
 
       # Converts object to Hiera-formatted YAML


### PR DESCRIPTION
This change allow us to default to the product's name when parsing the CPE that does not include product's version.