### PR TITLE
(GEM) Gem bump to 0.9.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.9.6)
+    abide_dev_utils (0.9.7)
       cmdparse (~> 3.0)
       google-cloud-storage (~> 1.34)
       hashdiff (~> 1.0)
@@ -143,13 +143,11 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
-    nokogiri (1.13.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.5.8)
     octokit (4.22.0)

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end


### PR DESCRIPTION
What this gem bump contains:
  - Update to fix the fault gem version 0.9.6