### PR TITLE
Diff updates

### DIFF
--- a/lib/abide_dev_utils/cli/xccdf.rb
+++ b/lib/abide_dev_utils/cli/xccdf.rb
@@ -104,6 +104,7 @@ module Abide
         options.on('-p [PROFILE]', '--profile', 'Only diff and specific profile in the benchmarks') do |x|
           @data[:profile] = x
         end
+        options.on('-r', '--raw', 'Output the diff in raw hash format') { @data[:raw] = true }
         options.on('-q', '--quiet', 'Show no output in the terminal') { @data[:quiet] = false }
         options.on('--no-diff-profiles', 'Do not diff the profiles in the XCCDF files') { @data[:diff_profiles] = false }
         options.on('--no-diff-controls', 'Do not diff the controls in the XCCDF files') { @data[:diff_controls] = false }

--- a/lib/abide_dev_utils/xccdf.rb
+++ b/lib/abide_dev_utils/xccdf.rb
@@ -153,25 +153,6 @@ module AbideDevUtils
         diff_properties.map { |x| send(x) } == other.diff_properties.map { |x| other.send(x) }
       end
 
-      def default_diff_opts
-        {
-          similarity: 1,
-          strict: true,
-          strip: true,
-          array_path: true,
-          delimiter: '//',
-          use_lcs: false
-        }
-      end
-
-      def diff(other, **opts)
-        Hashdiff.diff(
-          to_h,
-          other.to_h,
-          default_diff_opts.merge(opts)
-        )
-      end
-
       def abide_object?
         true
       end
@@ -244,33 +225,6 @@ module AbideDevUtils
           version: version,
           profiles: profiles.to_h
         }
-      end
-
-      def diff_title_version(other)
-        Hashdiff.diff(
-          to_h.reject { |k, _| k.to_s == 'profiles' },
-          other.to_h.reject { |k, _| k.to_s == 'profiles' },
-          default_diff_opts
-        )
-      end
-
-      def diff_profiles(other)
-        this_diff = {}
-        other_hash = other.to_h[:profiles]
-        to_h[:profiles].each do |name, data|
-          diff_h = Hashdiff.diff(data, other_hash[name], default_diff_opts).each_with_object({}) do |x, a|
-            val_to = x.length == 4 ? x[3] : nil
-            a_key = x[2].is_a?(Hash) ? x[2][:title] : x[2]
-            a[a_key] = [] unless a.key?(a_key)
-            a[a_key] << ChangeSet.new(change: x[0], key: x[1], value: x[2], value_to: val_to)
-          end
-          this_diff[name] = diff_h
-        end
-        this_diff
-      end
-
-      def diff_controls(other)
-        controls.diff(other.controls)
       end
 
       def map_indexed(index: 'title', framework: 'cis', key_prefix: '')

--- a/lib/abide_dev_utils/xccdf.rb
+++ b/lib/abide_dev_utils/xccdf.rb
@@ -34,21 +34,10 @@ module AbideDevUtils
 
     # Diffs two xccdf files
     def self.diff(file1, file2, opts)
+      require 'abide_dev_utils/xccdf/diff'
       bm1 = Benchmark.new(file1)
       bm2 = Benchmark.new(file2)
-      profile = opts.fetch(:profile, nil)
-      profile_diff = if profile.nil?
-                       bm1.diff_profiles(bm2).each do |_, v|
-                         v.transform_values! { |x| x.map!(&:to_s) }
-                       end
-                     else
-                       bm1.diff_profiles(bm2)[profile].transform_values! { |x| x.map!(&:to_s) }
-                     end
-      profile_key = profile.nil? ? 'all_profiles' : profile
-      {
-        'benchmark' => bm1.diff_title_version(bm2),
-        profile_key => profile_diff
-      }
+      AbideDevUtils::XCCDF::Diff.diff_benchmarks(bm1, bm2, opts)
     end
 
     # Common constants and methods included by nearly everything else

--- a/lib/abide_dev_utils/xccdf/diff.rb
+++ b/lib/abide_dev_utils/xccdf/diff.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'hashdiff'
+
+module AbideDevUtils
+  module XCCDF
+    # Contains methods and classes used to diff XCCDF-derived objects.
+    module Diff
+      # Represents a change in a diff.
+      class ChangeSet
+        attr_reader :change, :key, :value, :value_to
+
+        def initialize(change:, key:, value:, value_to: nil)
+          validate_change(change)
+          @change = change
+          @key = key
+          @value = value
+          @value_to = value_to
+        end
+
+        def to_s
+          val_to_str = value_to.nil? ? ' ' : " to #{value_to} "
+          "#{change_string} value #{value}#{val_to_str}at #{key}"
+        end
+
+        def can_merge?(other)
+          return false unless (change == '-' && other.change == '+') || (change == '+' && other.change == '-')
+          return false unless key == other.key || value_hash_equality(other)
+
+          true
+        end
+
+        def merge(other)
+          unless can_merge?(other)
+            raise ArgumentError, 'Cannot merge. Possible causes: change is identical; key or value do not match'
+          end
+
+          new_to_value = value == other.value ? nil : other.value
+          ChangeSet.new(
+            change: '~',
+            key: key,
+            value: value,
+            value_to: new_to_value
+          )
+        end
+
+        def merge!(other)
+          new_props = merge(other)
+          @change = new_props.change
+          @key = new_props.key
+          @value = new_props.value
+          @value_to = new_props.value_to
+        end
+
+        private
+
+        def value_hash_equality(other)
+          equality = false
+          value.each do |k, v|
+            equality = true if v == other.value[k]
+          end
+          equality
+        end
+
+        def validate_change(change)
+          raise ArgumentError, "Change type #{change} in invalid" unless ['+', '-', '~'].include?(change)
+        end
+
+        def change_string
+          case change
+          when '-'
+            'remove'
+          when '+'
+            'add'
+          else
+            'change'
+          end
+        end
+      end
+
+      # Class used to diff two Benchmark profiles.
+      class ProfileDiff
+        DEFAULT_DIFF_OPTS = {
+          similarity: 1,
+          strict: true,
+          strip: true,
+          array_path: true,
+          delimiter: '//',
+          use_lcs: false
+        }.freeze
+
+        def initialize(profile_a, profile_b, opts = {})
+          @profile_a = profile_a
+          @profile_b = profile_b
+          @opts = opts
+        end
+
+        def diff
+          @diff ||= new_diff
+        end
+
+        private
+
+        def new_diff
+          Hashdiff.diff(profile_a, profile_b, DEFAULT_DIFF_OPTS).each_with_object({}) do |change, diff|
+            val_to = change.length == 4 ? change[3] : nil
+            change_key = change[2].is_a?(Hash) ? change[2][:title] : change[2]
+            diff[change_key] = [] unless diff.key?(change_key)
+            diff[change_key] << ChangeSet.new(change: change[0], key: change[1], value: change[2], value_to: val_to)
+          end
+        end
+      end
+
+      # Class used to diff two AbideDevUtils::XCCDF::Benchmark objects.
+      class BenchmarkDiff
+        DEFAULT_DIFF_OPTS = {
+          similarity: 1,
+          strict: true,
+          strip: true,
+          array_path: true,
+          delimiter: '//',
+          use_lcs: false
+        }.freeze
+
+        def initialize(benchmark_a, benchmark_b, opts = {})
+          @benchmark_a = benchmark_a
+          @benchmark_b = benchmark_b
+          @opts = opts
+        end
+
+        def properties_to_diff
+          @properties_to_diff ||= %i[title version profiles]
+        end
+
+        def title_version
+          @title_version ||= diff_title_version
+        end
+
+        def profiles
+          @profiles ||= diff_profiles
+        end
+
+        private
+
+        def diff_title_version
+          Hashdiff.diff(
+            @benchmark_a.to_h.reject { |k, _| k.to_s == 'profiles' },
+            @benchmark_b.to_h.reject { |k, _| k.to_s == 'profiles' },
+            DEFAULT_DIFF_OPTS
+          )
+        end
+
+        def diff_profiles(profile: nil)
+          diff = {}
+          other_hash = @benchmark_b.to_h[:profiles]
+          @benchmark_a.to_h[:profiles].each do |name, data|
+            next if profile && profile != name
+
+            diff[name] = ProfileDiff.new(data, other_hash[name], @opts).diff
+          end
+          diff
+        end
+      end
+
+      def self.diff_benchmarks(benchmark_a, benchmark_b, opts = {})
+        profile = opts.fetch(:profile, nil)
+        profile_key = profile.nil? ? 'all_profiles' : profile
+        benchmark_diff = BenchmarkDiff.new(benchmark_a, benchmark_b, opts)
+        diff = if profile.nil?
+                 benchmark_diff.diff_profiles.each do |_, v|
+                   v.transform_values! { |x| x.map!(&:to_s) }
+                 end
+               else
+                 benchmark_diff.diff_profiles(profile: profile)[profile].transform_values! { |x| x.map!(&:to_s) }
+               end
+        {
+          'benchmark' => benchmark_diff.diff_title_version,
+          profile_key => diff,
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- New file `lib/abide_dev_utils/xccdf/diff.rb` that holds classes and modules relevant to making benchmark diffs
- Updated output of benchmark diff to be more human friendly
- Added a flag to the xccdf diff command to output a raw, computer friendly diff hash