### PR TITLE
(CEM-525) Fix CIS map gen

### DIFF
--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/lib/abide_dev_utils/xccdf.rb
+++ b/lib/abide_dev_utils/xccdf.rb
@@ -619,11 +619,12 @@ module AbideDevUtils
       end
 
       def reference
-        @reference ||= @element_type == 'control' ? @xml['idref'] : @xml['id']
+        @reference ||= @element_type.include?('control') ? @xml['idref'] : @xml['id']
       end
 
       def hiera_title(**opts)
-        send("normalize_#{@element_type}_name".to_sym, @xml, **opts)
+        e_type = @element_type.include?('control') ? 'control' : 'profile'
+        send("normalize_#{e_type}_name".to_sym, @xml, **opts)
       end
 
       private


### PR DESCRIPTION
These changes hinge around `@element_type` which is determined by class name. Since we changed class names, these methods were returning `nil`.