### PR TITLE
Add guards to saving reference markdown files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.14.0)
+    abide_dev_utils (0.14.1)
       amatch (~> 0.4)
       cmdparse (~> 3.0)
       facterdb (>= 1.21)

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.14.0"
+  VERSION = "0.14.1"
 end


### PR DESCRIPTION
This PR adds some checks to ensure that a generated reference markdown is valid before saving it to the given file.