### PR TITLE
(CEM-2612) Reference generator will generate alt ID for STIG

### DIFF
--- a/lib/abide_dev_utils/cem/generate/reference.rb
+++ b/lib/abide_dev_utils/cem/generate/reference.rb
@@ -382,7 +382,12 @@ module AbideDevUtils
             # @valid_level is populated in verify_profile_and_level_selections from the fact that we've given
             # the generator a list of levels we want to use. If we didn't give it a list of levels, then we
             # want to use all of the levels that the control supports from @control.
-            @md.add_ul('Supported Levels:')
+            if @framework == 'stig'
+              @md.add_ul('Supported MAC Levels:')
+            else
+              @md.add_ul('Supported Levels:')
+            end
+
             if @valid_level.empty?
               @control.levels.each do |l|
                 @md.add_ul(@md.code(l), indent: 1)
@@ -400,7 +405,12 @@ module AbideDevUtils
             # @valid_profile is populated in verify_profile_and_level_selections from the fact that we've given
             # the generator a list of profiles we want to use. If we didn't give it a list of profiles, then we
             # want to use all of the profiles that the control supports from @control.
-            @md.add_ul('Supported Profiles:')
+            if @framework == 'stig'
+              @md.add_ul('Supported Confidentiality:')
+            else
+              @md.add_ul('Supported Profiles:')
+            end
+
             if @valid_profile.empty?
               @control.profiles.each do |l|
                 @md.add_ul(@md.code(l), indent: 1)
@@ -413,7 +423,7 @@ module AbideDevUtils
           end
 
           def control_alternate_ids_builder
-            return if @framework == 'stig'
+            # return if @framework == 'stig'
 
             @md.add_ul('Alternate Config IDs:')
             @control.alternate_ids.each do |l|


### PR DESCRIPTION
This commit enables the reference generate to genearte alternate ID for STIG benchmark. Also updated the level and profile builder to use 'MAC' level and 'Confidentiality' profile. Here's a snippet of the new generated doc for STIG benchmark:
```
### V-230493

* Parameters:
  * `conf_file` - [ `String[1]` ] - *Default:* `cem_disable_camera` - A unique name for the config file without a path of file extension
  * `content` - [ `Optional[String]` ] - *Default:* `install uvcvideo /bin/true
blacklist uvcvideo
` - The file content. Mutually exclusive with source.
* Supported MAC Levels:
  * `mac-2`
  * `mac-1`
  * `mac-3`
* Supported Confidentiality:
  * `classified`
  * `public`
  * `sensitive`
* Hiera Configuration Example:
```yaml
cem_linux::config:
  control_configs:
    "V-230493":
      conf_file: "cem_disable_camera"
      content: "install uvcvideo /bin/true\nblacklist uvcvideo\n"
```
```
* Alternate Config IDs:
  * `SV-230493r809316_rule`
* Resource: `Cem_linux::Utils::Modprobe_conf['STIG Disable camera']`
```
I don't know how to format on Github correctly, but alternate ID works with stig.