### PR TITLE
(CEM-3361) Fix existing issue check and optimize filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.17.0)
+    abide_dev_utils (0.17.1)
       cmdparse (~> 3.0)
       facterdb (>= 1.21)
       google-cloud-storage (~> 1.34)

--- a/lib/abide_dev_utils/cli/jira.rb
+++ b/lib/abide_dev_utils/cli/jira.rb
@@ -118,7 +118,12 @@ module Abide
         short_desc(CMD_SHORT)
         long_desc(CMD_LONG)
         argument_desc(PATH: 'An XCCDF file', PROJECT: 'A Jira project')
-        options.on('-d', '--dry-run', 'Print to console instead of saving objects') { |_| @data[:dry_run] = true }
+        options.on('-d', '--dry-run', 'Runs through mock issue creation. Useful for testing, but not reliable for knowing what exactly will be created. Use --explain for more accurate information.') do
+          @data[:dry_run] = true
+        end
+        options.on('-x', '--explain', 'Shows a report of all the controls that will and won\'t be created as issues, and why. DOES NOT create issues.') do
+          @data[:explain] = true
+        end
         options.on('-e [EPIC]', '--epic [EPIC]', 'If given, tasks will be created and assigned to this epic. Takes form <PROJECT>-<NUM>') { |e| @data[:epic] = e }
         options.on('-l [LEVEL]', '--level [LEVEL]', 'Only create tasks for rules belonging to the matching level. Takes a string that is treated as RegExp') do |x|
           @data[:level] = x
@@ -136,12 +141,13 @@ module Abide
         @data[:label_include] = nil
         @data[:label_include] = "level_#{@data[:level]}_" if @data[:level]
         @data[:label_include] = "#{@data[:label_include]}#{@data[:profile]}" if @data[:profile]
-        Abide::CLI::Output.simple "Label include: #{@data[:label_include]}"
+        Abide::CLI::OUTPUT.simple "Label include: #{@data[:label_include]}"
         AbideDevUtils::Jira.new_issues_from_xccdf(
           project,
           path,
           epic: @data[:epic],
           dry_run: @data[:dry_run],
+          explain: @data[:explain],
           label_include: @data[:label_include],
         )
       end

--- a/lib/abide_dev_utils/jira/client.rb
+++ b/lib/abide_dev_utils/jira/client.rb
@@ -47,6 +47,10 @@ module AbideDevUtils
         @helper ||= Helper.new(self, dry_run: @dry_run)
       end
 
+      def translate_issue_custom_field(name)
+        IssueBuilder::CUSTOM_FIELDS[name] || IssueBuilder::CUSTOM_FIELDS.invert[name]
+      end
+
       private
 
       def client

--- a/lib/abide_dev_utils/jira/finder.rb
+++ b/lib/abide_dev_utils/jira/finder.rb
@@ -32,6 +32,12 @@ module AbideDevUtils
         iss
       end
 
+      # @param jql [String] The JQL query
+      # @return [Array<JIRA::Resource::Issue>]
+      def issues_by_jql(jql)
+        client.Issue.jql(jql, max_results: 1000)
+      end
+
       # @param id [String] The issuetype ID or name
       def issuetype(id)
         return id if id.is_a?(client.Issuetype.target_class)

--- a/lib/abide_dev_utils/output.rb
+++ b/lib/abide_dev_utils/output.rb
@@ -10,6 +10,14 @@ require 'abide_dev_utils/files'
 module AbideDevUtils
   module Output
     FWRITER = AbideDevUtils::Files::Writer.new
+    def self.simple_section_separator(section_text, sepchar: '#', width: 60, **_)
+      section_text = section_text.to_s
+      section_text = section_text[0..width - 4] if section_text.length > width
+      section_text = " #{section_text} "
+      section_sep_line = sepchar * width
+      [section_sep_line, section_text.center(width, sepchar), section_sep_line].join("\n")
+    end
+
     def self.simple(msg, stream: $stdout, **_)
       case msg
       when Hash

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.17.0"
+  VERSION = "0.17.1"
 end


### PR DESCRIPTION
* Changed the naive check for issue summary to determine if an issue should be created for a control from a benchmark to also check for the epic in which the control is going to be created in. This allows controls with duplicate summaries but from different benchmarks to be created from an XCCDF.
* Optimized how issues from a project are queried.
* Added a new flag to `abide jira from-xccdf`: `--explain`
  * This new flag works similar to `--dry-run` in that it won't create any issues. However, instead of mimicking an actual creation run, it prints a detailed report of exactly what will be created, what wont, and why (via metadata).