### PR TITLE
(CEM-3370) Fix / enhance jira from-xccdf-diff command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.17.1)
+    abide_dev_utils (0.17.2)
       cmdparse (~> 3.0)
       facterdb (>= 1.21)
       google-cloud-storage (~> 1.34)

--- a/lib/abide_dev_utils/cli/jira.rb
+++ b/lib/abide_dev_utils/cli/jira.rb
@@ -163,6 +163,11 @@ module Abide
         long_desc(CMD_LONG)
         argument_desc(PATH1: 'An XCCDF file', PATH2: 'An XCCDF file', PROJECT: 'A Jira project')
         options.on('-d', '--dry-run', 'Print to console instead of saving objects') { |_| @data[:dry_run] = true }
+        options.on('-z', '--print-only', 'Prints a list of issues that would be created. Implies dry-run, and auto-approve, but less verbose than --dry-run.') do
+          @data[:print_only] = true
+          @data[:dry_run] = true
+          @data[:auto_approve] = true
+        end
         options.on('-y', '--yes', 'Automatically approve all yes / no prompts') { |_| @data[:auto_approve] = true }
         options.on('-e [EPIC]', '--epic [EPIC]', 'If given, tasks will be created and assigned to this epic. Takes form <PROJECT>-<NUM>') { |e| @data[:epic] = e }
         options.on('-p [PROFILE]', '--profile', 'Only diff rules belonging to the matching profile. Takes a string that is treated as RegExp') do |x|
@@ -188,8 +193,9 @@ module Abide
           path2,
           epic: @data[:epic],
           dry_run: @data[:dry_run],
+          print_only: @data[:print_only],
           auto_approve: @data[:auto_approve],
-          diff_opts: @data[:diff_opts],
+          diff_opts: @data[:diff_opts] || {},
         )
       end
     end

--- a/lib/abide_dev_utils/output.rb
+++ b/lib/abide_dev_utils/output.rb
@@ -27,6 +27,10 @@ module AbideDevUtils
       end
     end
 
+    def self.print(msg, stream: $stdout, **_)
+      stream.print msg
+    end
+
     def self.text(msg, console: false, file: nil, **_)
       simple(msg) if console
       FWRITER.write_text(msg, file: file) unless file.nil?

--- a/lib/abide_dev_utils/prompt.rb
+++ b/lib/abide_dev_utils/prompt.rb
@@ -1,25 +1,30 @@
 # frozen_string_literal: true
 
 require 'io/console'
+require_relative 'output'
 
 module AbideDevUtils
   module Prompt
-    def self.yes_no(msg, auto_approve: false)
-      return true if auto_approve
+    def self.yes_no(msg, auto_approve: false, stream: $stdout)
+      prompt_msg = "#{msg} (Y/n): "
+      if auto_approve
+        AbideDevUtils::Output.simple("#{prompt_msg}Y", stream: stream)
+        return true
+      end
 
-      print "#{msg} (Y/n): "
+      AbideDevUtils::Output.print(prompt_msg, stream: stream)
       return true if $stdin.cooked(&:gets).match?(/^[Yy].*/)
 
       false
     end
 
-    def self.single_line(msg)
-      print "#{msg}: "
+    def self.single_line(msg, stream: $stdout)
+      AbideDevUtils::Output.print("#{msg}: ", stream: stream)
       $stdin.cooked(&:gets).chomp
     end
 
-    def self.username
-      print 'Username: '
+    def self.username(stream: $stdout)
+      AbideDevUtils::Output.print('Username: ', stream: stream)
       $stdin.cooked(&:gets).chomp
     end
 

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.17.1"
+  VERSION = "0.17.2"
 end


### PR DESCRIPTION
Fixed an issue with the `abide jira from-xccdf-diff` command where the command method attempted to call a method on an object that would never exist during epic title creation if an epic was not supplied.

I also took the opportunity to improve some of the console outputs for this command.

Additionally, I implemented a new flag for this command, `--print-only`, which is a faster, less verbose version of `--dry-run`. This makes it more useful for examining exactly what issues will be created for a live run of the command.