### PR TITLE
(CEM-3780) Fix indentation and generation error reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.18.0)
+    abide_dev_utils (0.18.1)
       cmdparse (~> 3.0)
       facterdb (>= 1.21)
       google-cloud-storage (~> 1.34)

--- a/lib/abide_dev_utils/errors/sce.rb
+++ b/lib/abide_dev_utils/errors/sce.rb
@@ -28,5 +28,12 @@ module AbideDevUtils
     class ControlIdFrameworkMismatchError < GenericError
       @default = 'Control ID is invalid with the given framework:'
     end
+
+    # Raised when a benchmark fails to load for a non-specific reason
+    class BenchmarkLoadError < GenericError
+      attr_accessor :framework, :osname, :major_version, :module_name, :original_error
+
+      @default = 'Error loading benchmark:'
+    end
   end
 end

--- a/lib/abide_dev_utils/markdown.rb
+++ b/lib/abide_dev_utils/markdown.rb
@@ -30,9 +30,9 @@ module AbideDevUtils
       end
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       if name.to_s.start_with?('add_')
-        add(name.to_s.sub('add_', '').to_sym, *args, &block)
+        add(name.to_s.sub('add_', '').to_sym, *args, **kwargs, &block)
       else
         super
       end

--- a/lib/abide_dev_utils/sce/benchmark.rb
+++ b/lib/abide_dev_utils/sce/benchmark.rb
@@ -337,51 +337,6 @@ module AbideDevUtils
         @controls = resources.map(&:controls).flatten.sort
       end
 
-      # Creates Benchmark objects from a Puppet module
-      # @param pupmod [AbideDevUtils::Ppt::PuppetModule] A PuppetModule instance
-      # @param skip_errors [Boolean] True skips errors and loads non-erroring benchmarks, false raises the error.
-      # @return [Array<AbideDevUtils::Sce::Benchmark>] Array of Benchmark instances
-      def self.benchmarks_from_puppet_module(pupmod, ignore_all_errors: false, ignore_framework_mismatch: true)
-        frameworks = pupmod.hiera_conf.local_hiera_files(hierarchy_name: 'Mapping Data').each_with_object([]) do |hf, ary|
-          parts = hf.path.split(pupmod.hiera_conf.default_datadir)[-1].split('/')
-          ary << parts[2] unless ary.include?(parts[2])
-        end
-        pupmod.supported_os.each_with_object([]) do |supp_os, ary|
-          osname, majver = supp_os.split('::')
-          if majver.is_a?(Array)
-            majver.sort.each do |v|
-              frameworks.each do |fw|
-                benchmark = Benchmark.new(osname,
-                                          v,
-                                          pupmod.hiera_conf,
-                                          pupmod.name(strip_namespace: true),
-                                          framework: fw)
-                benchmark.controls
-                ary << benchmark
-              rescue AbideDevUtils::Errors::MappingDataFrameworkMismatchError => e
-                raise e unless ignore_all_errors || ignore_framework_mismatch
-              rescue StandardError => e
-                raise e unless ignore_all_errors
-              end
-            end
-          else
-            frameworks.each do |fw|
-              benchmark = Benchmark.new(osname,
-                                        majver,
-                                        pupmod.hiera_conf,
-                                        pupmod.name(strip_namespace: true),
-                                        framework: fw)
-              benchmark.controls
-              ary << benchmark
-            rescue AbideDevUtils::Errors::MappingDataFrameworkMismatchError => e
-              raise e unless ignore_all_errors || ignore_framework_mismatch
-            rescue StandardError => e
-              raise e unless ignore_all_errors
-            end
-          end
-        end
-      end
-
       def map_data
         mapper.map_data
       end

--- a/lib/abide_dev_utils/sce/benchmark_loader.rb
+++ b/lib/abide_dev_utils/sce/benchmark_loader.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require_relative '../ppt/puppet_module'
+require_relative 'benchmark'
+
+module AbideDevUtils
+  module Sce
+    # Namespace for classes and methods for loading benchmarks
+    module BenchmarkLoader
+      # Load benchmarks from a Puppet module
+      # @param module_dir [String] the directory of the Puppet module
+      # @param opts [Hash] options for loading the benchmarks
+      # @option opts [Boolean] :ignore_all_errors ignore all errors when loading benchmarks
+      # @option opts [Boolean] :ignore_framework_mismatch ignore errors when the framework doesn't match
+      # @return [Array<AbideDevUtils::Sce::Benchmark>] the loaded benchmarks
+      def self.benchmarks_from_puppet_module(module_dir = Dir.pwd, **opts)
+        PupMod.new(module_dir, **opts).load
+      end
+
+      # Loads benchmark data for a Puppet module
+      class PupMod
+        attr_reader :pupmod, :load_errors, :load_warnings, :ignore_all_errors, :ignore_framework_mismatch
+
+        def initialize(module_dir = Dir.pwd, **opts)
+          @pupmod = AbideDevUtils::Ppt::PuppetModule.new(module_dir)
+          @load_errors = []
+          @load_warnings = []
+          @ignore_all_errors = opts.fetch(:ignore_all_errors, false)
+          @ignore_framework_mismatch = opts.fetch(:ignore_framework_mismatch, false)
+        end
+
+        # Load the benchmark from the Puppet module
+        # @return [Array<AbideDevUtils::Sce::Benchmark>] the loaded benchmarks
+        # @raise [AbideDevUtils::Errors::BenchmarkLoadError] if a benchmark fails to load
+        def load
+          clear_load_errors
+          clear_load_warnings
+          pupmod.supported_os.each_with_object([]) do |supp_os, ary|
+            osname, majver = supp_os.split('::')
+            if majver.is_a?(Array)
+              majver.sort.each do |v|
+                frameworks.each do |fw|
+                  ary << new_benchmark(osname, v, fw)
+                rescue StandardError => e
+                  handle_load_error(e, fw, osname, v, pupmod.name(strip_namespace: true))
+                end
+              end
+            else
+              frameworks.each do |fw|
+                ary << new_benchmark(osname, majver, fw)
+              rescue StandardError => e
+                handle_load_error(e, fw, osname, majver, pupmod.name(strip_namespace: true))
+              end
+            end
+          end
+        end
+
+        private
+
+        def clear_load_errors
+          @load_errors = []
+        end
+
+        def clear_load_warnings
+          @load_warnings = []
+        end
+
+        def frameworks
+          @frameworks ||= pupmod.hiera_conf.local_hiera_files(hierarchy_name: 'Mapping Data').each_with_object([]) do |hf, ary|
+            parts = hf.path.split(pupmod.hiera_conf.default_datadir)[-1].split('/')
+            ary << parts[2] unless ary.include?(parts[2])
+          end
+        end
+
+        def new_benchmark(osname, majver, framework)
+          benchmark = AbideDevUtils::Sce::Benchmark.new(
+            osname,
+            majver,
+            pupmod.hiera_conf,
+            pupmod.name(strip_namespace: true),
+            framework: framework
+          )
+          benchmark.controls
+          benchmark
+        end
+
+        def handle_load_error(error, framework, osname, majver, module_name)
+          err = AbideDevUtils::Errors::BenchmarkLoadError.new(error.message)
+          err.set_backtrace(error.backtrace)
+          err.framework = framework
+          err.osname = osname
+          err.major_version = majver
+          err.module_name = module_name
+          err.original_error = error
+          if error.is_a?(AbideDevUtils::Errors::MappingDataFrameworkMismatchError) && ignore_framework_mismatch
+            @load_warnings << err
+          elsif ignore_all_errors
+            @load_errors << err
+          else
+            @load_errors << err
+            raise err
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/abide_dev_utils/sce/generate/coverage_report.rb
+++ b/lib/abide_dev_utils/sce/generate/coverage_report.rb
@@ -4,9 +4,9 @@ require 'date'
 require 'json'
 require 'pathname'
 require 'yaml'
-require 'abide_dev_utils/ppt'
-require 'abide_dev_utils/validate'
-require 'abide_dev_utils/sce/benchmark'
+require_relative '../../ppt'
+require_relative '../../validate'
+require_relative '../benchmark_loader'
 
 module AbideDevUtils
   module Sce
@@ -16,9 +16,9 @@ module AbideDevUtils
       module CoverageReport
         def self.generate(format_func: :to_h, opts: {})
           opts = ReportOptions.new(opts)
-          pupmod = AbideDevUtils::Ppt::PuppetModule.new
-          benchmarks = AbideDevUtils::Sce::Benchmark.benchmarks_from_puppet_module(pupmod,
-                                                                                   ignore_all_errors: opts.ignore_all_errors)
+          benchmarks = AbideDevUtils::Sce::BenchmarkLoader.benchmarks_from_puppet_module(
+            ignore_all_errors: opts.ignore_all_errors
+          )
           benchmarks.map do |b|
             BenchmarkReport.new(b, opts).run.send(format_func)
           end

--- a/lib/abide_dev_utils/sce/hiera_data/.resource_data.rb
+++ b/lib/abide_dev_utils/sce/hiera_data/.resource_data.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'abide_dev_utils/errors'
-require 'abide_dev_utils/ppt/facter_utils'
-require 'abide_dev_utils/sce/hiera_data/resource_data/control'
-require 'abide_dev_utils/sce/hiera_data/resource_data/resource'
+# This should be unused, keeping around incase shit breaks and it's needed
+require_relative '../../../errors'
+require_relative '../../../ppt/facter_utils'
+require_relative '../benchmark_loader'
 
 module AbideDevUtils
   module Sce

--- a/lib/abide_dev_utils/sce/hiera_data/resource_data/.control.rb
+++ b/lib/abide_dev_utils/sce/hiera_data/resource_data/.control.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This should be unused, keeping around incase shit breaks and it's needed
 require 'abide_dev_utils/dot_number_comparable'
 require 'abide_dev_utils/errors'
 require 'abide_dev_utils/sce/hiera_data/mapping_data'

--- a/lib/abide_dev_utils/sce/hiera_data/resource_data/.parameters.rb
+++ b/lib/abide_dev_utils/sce/hiera_data/resource_data/.parameters.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This should be unused, keeping around incase shit breaks and it's needed
 require 'set'
 
 module AbideDevUtils

--- a/lib/abide_dev_utils/sce/hiera_data/resource_data/.resource.rb
+++ b/lib/abide_dev_utils/sce/hiera_data/resource_data/.resource.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This should be unused, keeping around incase shit breaks and it's needed
 require 'set'
 require 'abide_dev_utils/errors'
 require 'abide_dev_utils/sce/hiera_data/resource_data/control'

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.18.0"
+  VERSION = "0.18.1"
 end

--- a/spec/abide_dev_utils/cli_spec.rb
+++ b/spec/abide_dev_utils/cli_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Abide::CLI do
             select_profile: %w[profile1 profile2],
             select_level: %w[1 2]
           }
-        )
+        ).and_return([[], []])
       )
       capture_stdout_stderr do
         described_class.execute(

--- a/spec/abide_dev_utils/sce/benchmark_spec.rb
+++ b/spec/abide_dev_utils/sce/benchmark_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-# require 'abide_dev_utils/ppt'
-# require 'abide_dev_utils/sce/benchmark'
 
 RSpec.describe('AbideDevUtils::Sce::Benchmark') do
   { sce_linux: sce_linux_fixture, sce_windows: sce_windows_fixture }.each do |mname, fix|
@@ -12,7 +10,9 @@ RSpec.describe('AbideDevUtils::Sce::Benchmark') do
       test_objs = []
       Dir.chdir(fix) do
         test_objs << AbideDevUtils::Ppt::PuppetModule.new
-        test_objs << AbideDevUtils::Sce::Benchmark.benchmarks_from_puppet_module(test_objs.first)
+        test_objs << AbideDevUtils::Sce::BenchmarkLoader.benchmarks_from_puppet_module(
+          ignore_framework_mismatch: true
+        )
       end
 
       context 'when supplied a PuppetModule' do


### PR DESCRIPTION
* Fixes unordered lists in markdown not being properly indented
  * See `lib/abide_dev_utils/markdown.rb` for this specific fix.
  * This fix was needed because Ruby 3.0 no long allows keyword arguments to be passed with `*arg` syntax, you must use `**arg` syntax.
* Refactors benchmark loading code
  * This change was made primarily to simplify the Benchmark object.
* Framework mismatch errors no longer cause failures when generating the reference.
  * This change allows for operating systems that don't support STIG to not raise errors when the reference is created for them. Now, warnings are returned and logged instead.
* Renamed some old, unused files with a `.` prefix. Keeping them around incase they are actually needed.