### PR TITLE
(CEM-3793) Fix refgen profile / level mismatch

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
---format documentation
+--format progress
 --color
 --require spec_helper


### PR DESCRIPTION
This PR fixes an issue where generated references would display invalid profile / level combinations for controls. For example, previously if a control belonged to `server level 2`, `workstation level 1`, and `workstation level 2`, the generated reference would list levels 1 and 2 as supported even if you specified only the `server` profile when generating it. Now, the full profile and level are listed out when the reference is generated.

Example (previous):
```text
### 5.3.6 - Ensure SSH X11 forwarding is disabled

* Supported Levels:
* `level_1`
* `level_2`
* Supported Profiles:
* `server`
```

Example (new):
```text
### 4.2.12 - Ensure SSH X11 forwarding is disabled

#### Supported Profiles & Levels:

  * `server, level_2`
  * `workstation, level_1`
  * `workstation, level_2`
```

In the above examples, the different formatting (using headers instead of UL bullets) was introduced in a previous PR.