### PR TITLE
(CEM-4953) Pin facterdb version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.18.1)
+    abide_dev_utils (0.18.2)
       cmdparse (~> 3.0)
-      facterdb (>= 1.21)
+      facterdb (~> 2.1.0)
       google-cloud-storage (~> 1.34)
       hashdiff (~> 1.0)
       jira-ruby (~> 2.2)
@@ -61,9 +61,9 @@ GEM
     facter (4.4.1)
       hocon (~> 1.3)
       thor (>= 1.0.1, < 2.0)
-    facterdb (1.21.0)
+    facterdb (2.1.0)
       facter (< 5.0.0)
-      jgrep
+      jgrep (~> 1.5, >= 1.5.4)
     faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)

--- a/abide_dev_utils.gemspec
+++ b/abide_dev_utils.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'selenium-webdriver', '~> 4.0.0.beta4'
   spec.add_dependency 'google-cloud-storage', '~> 1.34'
   spec.add_dependency 'hashdiff', '~> 1.0'
-  spec.add_dependency 'facterdb', '>= 1.21'
+  spec.add_dependency 'facterdb', '~> 2.1.0'
   spec.add_dependency 'metadata-json-lint', '~> 4.0'
 
   # Dev dependencies

--- a/lib/abide_dev_utils/errors/sce.rb
+++ b/lib/abide_dev_utils/errors/sce.rb
@@ -34,6 +34,16 @@ module AbideDevUtils
       attr_accessor :framework, :osname, :major_version, :module_name, :original_error
 
       @default = 'Error loading benchmark:'
+
+      def message
+        [
+          "#{super} (#{original_error.class})",
+          "Framework: #{framework}",
+          "OS Name: #{osname}",
+          "OS Version: #{major_version}",
+          "Module Name: #{module_name}"
+        ].join(', ')
+      end
     end
   end
 end

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.18.1"
+  VERSION = "0.18.2"
 end


### PR DESCRIPTION
As of [facterdb v3.0.0](https://github.com/voxpupuli/facterdb/blob/master/CHANGELOG.md#300-2024-06-10), fact sets for CentOS 7 and 8 were removed. This breaks the reference generator and, because we were using optimistic pinning of that dependency, it breaks in Github actions.

This PR updates the benchmark load error message to be more verbose. This verbosity led me to the facterdb issue, which has been fixed by explicitly pinning it to `v2.1.x`.