### PR TITLE
(MAINT) Bump gem version to 0.18.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.18.3)
+    abide_dev_utils (0.18.4)
       cmdparse (~> 3.0)
       facterdb (~> 2.1.0)
       google-cloud-storage (~> 1.34)

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.18.3"
+  VERSION = "0.18.4"
 end


### PR DESCRIPTION
This new gem version contain a small update to the reference generator that include a section about controls that use plans andn tasks.