### PR TITLE
(CEM-6709) Add RHEL 10 fact set and project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+`abide_dev_utils` is a Ruby gem that ships an `abide` CLI used by the Abide / Puppet SCE (Security Compliance Enforcement) team to develop compliance Puppet modules (CIS, STIG). The CLI converts XCCDF benchmarks into Hiera, generates mappings, builds coverage and reference reports against SCE modules, integrates with Jira, and (legacy) scrapes Puppet Comply.
+
+The gem requires Ruby >= 2.7.0; CI runs on 3.2. The gem `puppet` is only installed when `PUPPET_AUTH_TOKEN` is set (it pulls from `rubygems-puppetcore.puppet.com`) — see `Gemfile`.
+
+## Common commands
+
+```sh
+bin/setup                      # bundle install + initial setup
+bundle exec rake               # default: spec + rubocop
+bundle exec rake spec          # run all RSpec tests
+bundle exec rspec spec/abide_dev_utils/sce/benchmark_spec.rb   # single file
+bundle exec rspec spec/path/to_spec.rb:42                      # single example by line
+bundle exec rubocop            # lint
+bundle exec rake build         # build gem into pkg/
+bundle exec rake install       # build + install locally
+bin/console                    # IRB with the gem preloaded
+bundle exec exe/abide -h       # run the CLI from a checkout
+```
+
+### SCE fixture modules (required for many specs)
+
+Several specs and the coverage/reference generators load real Puppet modules from `spec/fixtures/`. Fetch them with:
+
+```sh
+bundle exec rake sce:fixtures             # clone all available fixture modules
+bundle exec rake 'sce:fixture[linux]'     # clone a single fixture by partial name
+```
+
+The fixtures are cloned over SSH from `git@github.com:puppetlabs/<module>.git` (`puppetlabs-cem_linux`, `puppetlabs-sce_linux`, `puppetlabs-cem_windows`, `puppetlabs-sce_windows`). CI uses `webfactory/ssh-agent` with deploy keys; locally you need SSH access to those repos. Specs that require a fixture will fail if you skipped the clone.
+
+`spec_helper.rb` exposes `sce_linux_fixture` / `sce_windows_fixture` helpers that prefer the `sce_*` repo and fall back to the older `cem_*` name.
+
+## Architecture
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for a full breakdown of the file layout and architectural conventions.
+
+## Release flow
+
+`bundle exec rake release` builds the gem, tags the version in git, pushes, and pushes to rubygems.org. Bump `lib/abide_dev_utils/version.rb` first.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    abide_dev_utils (0.18.5)
+    abide_dev_utils (0.18.6)
       cmdparse (~> 3.0)
       facterdb (~> 4.1.0)
       google-cloud-storage (~> 1.34)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,264 @@
+# Architecture
+
+This document describes the file/directory layout of `abide_dev_utils` so contributors and AI assistants can find the right place to make a change. For build/test commands, see `CLAUDE.md` and `README.md`.
+
+`abide_dev_utils` is a developer helper for the **`puppetlabs-sce_linux`** and **`puppetlabs-sce_windows`** Puppet SCE modules. Most of the design choices in this repo (the `sce/` subsystem, the fixture-cloning rake task, the local fact sets in `files/`) exist to support those two modules, so when something in the architecture seems oddly specific, it's almost always because one of those modules needed it.
+
+## Top-level layout
+
+```
+abide_dev_utils/
+├── exe/                 ← gem-installed CLI binary
+├── bin/                 ← in-repo dev binaries + setup script
+├── lib/                 ← all library + CLI code (see lib/ section below)
+├── spec/                ← RSpec tests, mirroring lib/ layout
+├── files/               ← static resources shipped with the gem
+├── docs/                ← contributor-facing docs (this file lives here)
+├── pkg/                 ← rake build output (.gem files); not committed source
+├── Gemfile / .gemspec   ← dependency + gem metadata
+├── Rakefile             ← spec/rubocop/build tasks + sce:fixtures clone task
+├── new_diff.rb          ← ad-hoc one-off script (not wired into the CLI)
+└── README.md / CHANGELOG.md / LICENSE.txt / CODEOWNERS
+```
+
+The unusual ones:
+
+- **`exe/abide`** is the Bundler-recommended location for installed binaries; `spec.executables = ['abide']` in the gemspec wires it up.
+- **`bin/abide.rb`** is a duplicate entry point used during development so you can `ruby bin/abide.rb ...` without installing the gem. `bin/console` is an IRB session with the gem preloaded; `bin/setup` is the `bundle install` bootstrap.
+- **`new_diff.rb`** is a developer scratch script that exercises the XCCDF diff code; it's not part of the public CLI surface.
+- **`pkg/`** is rake build output. Don't edit anything in there.
+- **`files/fact_sets/`** holds locally-stored fact sets used as a FacterDB fallback. `abide sce generate reference` (the `REFERENCE.md` generator) relies on the `facterdb` gem to look up facts for every OS that `sce_linux` / `sce_windows` declare in their `metadata.json`. When one of those modules adds support for a brand-new OS release, FacterDB doesn't always have a matching fact set yet — in that case we drop a `<os>-<version>-<arch>.facts` file (e.g. `windows-2025-x86_64.facts`) into `files/fact_sets/` and `ppt/facter_utils.rb` loads it instead. Once FacterDB ships the fact set upstream, the file here can be removed.
+
+## `lib/abide_dev_utils/` — library + CLI
+
+The whole gem lives under one namespace. `lib/abide_dev_utils.rb` is the require-everything entry point; the rest of the structure pairs each top-level CLI namespace with a sibling library directory.
+
+```
+lib/abide_dev_utils.rb              ← top-level require: pulls in every domain
+lib/abide_dev_utils/
+├── cli.rb                          ← cmdparse setup; registers the 6 top-level commands
+├── cli/                            ← one file per top-level CLI namespace
+│
+├── sce.rb        sce/              ← `abide sce ...` library
+├── xccdf.rb      xccdf/            ← `abide xccdf ...` library
+├── ppt.rb        ppt/              ← `abide puppet ...` library + shared Puppet helpers
+├── jira.rb       jira/             ← `abide jira ...` library
+├── comply.rb                       ← `abide comply ...` library (deprecated, no subdir)
+│
+├── config.rb                       ← reads ~/.abide_dev.yaml
+├── files.rb                        ← Reader/Writer dispatching on extension
+├── output.rb                       ← simple/text/json/yaml/progress writers
+├── validate.rb                     ← file/directory/hashable/puppet_module_directory checks
+├── prompt.rb                       ← interactive y/n prompt used by jira flows
+├── markdown.rb                     ← tiny Markdown builder used by sce reference generator
+├── gcloud.rb                       ← google-cloud-storage wrapper (loaded but unused by CLI)
+├── puppet_strings.rb               ← shared puppet-strings helpers
+├── mixins.rb                       ← misc reusable mixins
+├── dot_number_comparable.rb        ← <=> for dotted CIS ids ("1.2.10" > "1.2.2")
+├── constants.rb                    ← CliConstants
+├── version.rb                      ← VERSION string (bump before `rake release`)
+│
+├── errors.rb     errors/           ← typed exception classes, namespaced per domain
+└── resources/                      ← ERB templates shipped with the gem (e.g. generic_spec.erb)
+```
+
+### `cli/` — CLI command classes
+
+One file per top-level `abide <namespace>` command. Each file defines a `*Command` class plus its subcommands.
+
+```
+cli/
+├── abstract.rb     ← AbideCommand base class (handles [DEPRECATED] tagging, mixes in Config)
+├── sce.rb          ← `abide sce {generate,update-config,validate} ...`
+├── xccdf.rb        ← `abide xccdf {to_hiera,diff,gen-map}`
+├── puppet.rb       ← `abide puppet {coverage,new,...}`
+├── jira.rb         ← `abide jira {auth,from_coverage,from_xccdf,new_issue,get_issue}`
+├── comply.rb       ← `abide comply report` (DEPRECATED)
+└── test.rb         ← `abide test` (DEPRECATED, currently broken)
+```
+
+All command classes inherit from `Abide::CLI::AbideCommand` (defined in `cli/abstract.rb`), which wraps `CmdParse::Command`, mixes in `AbideDevUtils::Config`, and prefixes short/long descriptions with `[DEPRECATED]` when `deprecated: true` is passed. Don't subclass `CmdParse::Command` directly when adding new commands.
+
+### `sce/` — Security Compliance Enforcement domain
+
+The largest subsystem. Operates on Puppet SCE modules on disk (`puppetlabs-sce_linux`, `puppetlabs-sce_windows`, etc.) and produces coverage reports, reference docs, and validation output.
+
+```
+sce.rb                                ← top-level entry; defines update_legacy_config_from_diff
+sce/
+├── benchmark_loader.rb               ← walks a Puppet module's supported_os × frameworks
+│                                       and constructs Benchmark objects (errors are
+│                                       collected, not raised)
+├── benchmark.rb                      ← Benchmark / Resource / Control domain model
+│                                       (Control mixes in DotNumberComparable)
+│
+├── generate.rb     generate/         ← `abide sce generate ...`
+│   ├── coverage_report.rb            ← coverage-report subcommand
+│   └── reference.rb                  ← reference (REFERENCE.md) subcommand
+│
+├── validate.rb     validate/         ← `abide sce validate ...`
+│   ├── resource_data.rb              ← validates data/resource_data/*.yaml
+│   ├── strings.rb                    ← runs puppet-strings over the module
+│   └── strings/                      ← per-Puppet-type validators
+│       ├── base_validator.rb
+│       ├── puppet_class_validator.rb
+│       ├── puppet_defined_type_validator.rb
+│       └── validation_finding.rb
+│
+├── mapping/                          ← id ↔ id mapping (control numbers, hiera titles, ...)
+│   └── mapper.rb                     ← Mapper, MapData, ALL_TYPES / FRAMEWORK_TYPES enums
+│
+└── hiera_data.rb   hiera_data/       ← parsing the SCE module's data/ directory
+    ├── mapping_data.rb               ← entry point for data/mapping/*.yaml
+    ├── mapping_data/
+    │   ├── map_data.rb               ← parses one mapping YAML file
+    │   └── mixins.rb                 ← MixinCIS / MixinSTIG (per-framework lookup logic)
+    └── resource_data/                ← (placeholder; reserved for resource_data parsers)
+```
+
+`sce.rb` plus everything in `sce/` is what powers the `abide sce` CLI. The pattern of *"top-level `.rb` requires the subdirectory"* is consistent across the codebase — `sce/generate.rb` requires `sce/generate/*.rb`, and so on.
+
+### `xccdf/` — XCCDF parsing and conversion
+
+```
+xccdf.rb                              ← entry points (gen_map, to_hiera, diff) +
+│                                       XCCDF::Common (CIS/STIG regex constants) +
+│                                       XCCDF::Benchmark
+xccdf/
+├── parser.rb       parser/           ← Nokogiri-based parser
+│   ├── helpers.rb
+│   └── objects.rb  objects/
+│       ├── numbered_object.rb        ← controls/profiles with dotted numbers
+│       └── diffable_object.rb        ← objects participating in benchmark diffing
+│
+├── diff.rb                           ← BenchmarkDiff (used by `abide xccdf diff` and the
+│                                       currently-disabled `sce update-config from-diff`)
+└── utils.rb                          ← shared XCCDF helpers
+```
+
+`XCCDF::Common` (in `xccdf.rb`) is the **single source of truth** for CIS vs STIG conventions: control-id regexes, profile-level codes, the `normalize_string` / `normalize_control_name` / `normalize_profile_name` helpers that the README documents. Touching the constants in `Common` affects mapping generation, Hiera key naming, and diffing simultaneously.
+
+### `ppt/` — Puppet-module utilities
+
+Used both by the `sce/` subsystem (to read manifests off disk) and directly by the `abide puppet ...` commands.
+
+```
+ppt.rb                                ← top-level helpers: rename_puppet_class, build_new_object,
+│                                       audit/fix_class_names, add_cis_comment, score_module
+ppt/
+├── puppet_module.rb                  ← PuppetModule class: reads metadata.json, hiera.yaml;
+│                                       exposes supported_os used by BenchmarkLoader
+├── class_utils.rb                    ← Puppet class name ↔ on-disk path conversions
+├── code_introspection.rb             ← parses Puppet manifests (used by Resource.manifest)
+├── hiera.rb                          ← Hiera::Config wrapper for a module's hiera.yaml
+├── facter_utils.rb                   ← FacterDB integration; can also load files/fact_sets/*.facts
+├── strings.rb                        ← puppet-strings helpers
+├── api.rb                            ← misc Puppet API glue
+├── new_obj.rb                        ← `abide puppet new` ERB-based generator
+│                                       (honours c-/d- filename prefixes for spec dir routing)
+├── score_module.rb                   ← stub; Ppt.score_module currently prints "not implemented"
+│
+└── code_gen.rb     code_gen/         ← AST-style wrappers for code generation
+    ├── generate.rb
+    ├── data_types.rb
+    ├── resource.rb
+    ├── resource_types.rb
+    └── resource_types/
+        ├── base.rb
+        ├── class.rb
+        ├── manifest.rb
+        ├── parameter.rb
+        └── strings.rb
+```
+
+### `jira/` — Jira integration
+
+```
+jira.rb                               ← top-level flows: new_issues_from_coverage,
+│                                       new_issues_from_xccdf, summary helpers.
+│                                       Defines summary prefixes (COV_PARENT_SUMMARY_PREFIX,
+│                                       COV_CHILD_SUMMARY_PREFIX, UPD_EPIC_SUMMARY_PREFIX)
+│                                       used to recognise issues this tool created.
+jira/
+├── client.rb                         ← jira-ruby client wrapper
+├── client_builder.rb                 ← builds a client from ~/.abide_dev.yaml's jira section
+├── dry_run.rb                        ← drop-in replacement returned when --dry-run is set
+├── finder.rb                         ← search existing issues
+├── issue_builder.rb                  ← payload construction for create/update
+└── helper.rb                         ← project-level convenience (all_project_issues_attrs, etc.)
+```
+
+### `errors/` — typed exceptions
+
+```
+errors.rb                             ← requires the per-domain files
+errors/
+├── base.rb                           ← AbideDevUtils::Errors::* base class
+├── general.rb                        ← cross-cutting errors (FileNotFoundError, etc.)
+├── sce.rb                            ← BenchmarkLoadError (carries osname, major_version,
+│                                       framework, module_name, original_error fields that
+│                                       cli/sce.rb pretty-prints via respond_to?)
+├── xccdf.rb                          ← UnsupportedXCCDFError, ProfilePartsError, ControlPartsError
+├── ppt.rb                            ← Puppet-module errors (ClassFileNotFoundError, ...)
+├── jira.rb                           ← Jira-specific errors
+├── comply.rb                         ← Comply scraper errors (deprecated)
+└── gcloud.rb                         ← GCS errors
+```
+
+When introducing a new "soft" error that the CLI should pretty-print rather than raise, follow the `BenchmarkLoadError` pattern: subclass the matching domain error and expose extra metadata as accessors. The CLI uses `respond_to?` to decide which fields to render.
+
+### `comply.rb` — deprecated Selenium scraper
+
+A single file (no `comply/` subdirectory) that drives `selenium-webdriver` against the Puppet Comply UI. It's deprecated and still loaded mostly so the deprecation message stays visible. Don't extend it.
+
+## `spec/` — tests
+
+The spec layout mirrors `lib/abide_dev_utils/`:
+
+```
+spec/
+├── spec_helper.rb                    ← requires every file under lib/ (catches load-order
+│                                       regressions); exposes TestResources / OutputHelpers
+├── abide_dev_utils_spec.rb           ← top-level smoke tests
+├── abide_dev_utils/                  ← mirrors lib/abide_dev_utils/ one-to-one
+│   ├── cli_spec.rb
+│   ├── xccdf_spec.rb
+│   ├── xccdf/
+│   │   ├── parser_spec.rb
+│   │   ├── parser/objects_spec.rb
+│   │   └── diff/benchmark_spec.rb
+│   ├── sce/benchmark_spec.rb
+│   └── ppt/
+│       ├── facter_utils_spec.rb
+│       └── new_obj_spec.rb
+│
+├── resources/                        ← committed test inputs (work without network)
+│   ├── cis/                          ← real CIS XCCDF files for parser tests
+│   │   ├── CIS_CentOS_Linux_7_Benchmark_v3.0.0-xccdf.xml
+│   │   └── CIS_Microsoft_Windows_Server_2016_..._v1.2.0-xccdf.xml
+│   └── test_files/                   ← small synthetic XCCDFs for diff/version tests
+│       ├── Test_XCCDF-v1.0.0-xccdf.xml
+│       └── Test_XCCDF-v1.1.0-xccdf.xml
+│
+└── fixtures/                         ← real Puppet SCE modules cloned at test time by
+                                        `rake sce:fixtures`. Not committed; required by
+                                        any spec that exercises BenchmarkLoader.
+    ├── puppetlabs-sce_linux/         ← clone of git@github.com:puppetlabs/puppetlabs-sce_linux
+    └── puppetlabs-sce_windows/       ← clone of git@github.com:puppetlabs/puppetlabs-sce_windows
+```
+
+`spec_helper.rb` exposes helpers via mixins: `sce_linux_fixture` / `sce_windows_fixture` (prefer the `sce_*` clone, fall back to `cem_*`), `test_xccdf_files`, `capture_stdout`, `capture_stderr`. RSpec is configured with `disable_monkey_patching!`, `verify_partial_doubles = true`, and `fail_fast = false` — keep partial doubles realistic.
+
+## How a request flows through the codebase
+
+Tracing `abide sce generate coverage-report` end-to-end is a good way to internalise the layout:
+
+1. **`exe/abide`** loads `lib/abide_dev_utils/cli.rb` and calls `Abide::CLI.execute`.
+2. **`cli.rb`** registers `SceCommand` (from `cli/sce.rb`) on the cmdparse parser.
+3. **`cli/sce.rb`** routes `generate coverage-report` to `SceGenerateCoverageReport#execute`, which collects flags into `@data` and calls `AbideDevUtils::Sce::Generate::CoverageReport.generate(...)`.
+4. **`sce/generate/coverage_report.rb`** asks `BenchmarkLoader::PupMod` (in `sce/benchmark_loader.rb`) to load benchmarks from the current directory.
+5. **`benchmark_loader.rb`** instantiates a `Ppt::PuppetModule` (from `ppt/puppet_module.rb`), reads `metadata.json` for `supported_os`, and constructs one `Sce::Benchmark` per (OS, version, framework) cell.
+6. Each **`Sce::Benchmark`** (in `sce/benchmark.rb`) builds a `Mapping::Mapper` (from `sce/mapping/mapper.rb`) over the module's `data/mapping/*.yaml` files, and a list of `Resource` objects whose manifests are parsed by `Ppt::CodeIntrospection::Manifest` (from `ppt/code_introspection.rb`).
+7. The coverage report is serialised through **`output.rb`** as YAML/JSON/text, optionally written to a file via **`files.rb`**'s `Writer`.
+
+Every other command follows the same shape: `cli/<name>.rb` parses options → top-level domain module orchestrates → domain classes do the work → `Output` writes the result.

--- a/files/fact_sets/redhat-10-x86_64.facts
+++ b/files/fact_sets/redhat-10-x86_64.facts
@@ -1,0 +1,606 @@
+{
+  "aio_agent_version": "8.23.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB693833ed-482419db",
+      "size": "10.00 GiB",
+      "size_bytes": 10737418240,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-b9cf1f28-4fba-4577-95b3-97983aacb94e",
+      "uuid": "281fcfb9-ba4f-7745-95b3-97983aacb94e",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "5.1.0",
+  "filesystems": "vfat,xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "169651",
+      "version": "7.1.12"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "6.12",
+  "kernelrelease": "6.12.0-55.29.1.el10_0.x86_64",
+  "kernelversion": "6.12.0",
+  "load_averages": {
+    "15m": 0.04,
+    "1m": 0.43,
+    "5m": 0.11
+  },
+  "memory": {
+    "system": {
+      "available": "553.72 MiB",
+      "available_bytes": 580620288,
+      "capacity": "42.02%",
+      "total": "955.06 MiB",
+      "total_bytes": 1001451520,
+      "used": "401.34 MiB",
+      "used_bytes": 420831232
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "4.62 GiB",
+      "available_bytes": 4962111488,
+      "capacity": "44.88%",
+      "device": "/dev/sda4",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "8.38 GiB",
+      "size_bytes": 9003180032,
+      "used": "3.76 GiB",
+      "used_bytes": 4041068544
+    },
+    "/boot": {
+      "available": "743.04 MiB",
+      "available_bytes": 779128832,
+      "capacity": "20.62%",
+      "device": "/dev/sda3",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "936.00 MiB",
+      "size_bytes": 981467136,
+      "used": "192.96 MiB",
+      "used_bytes": 202338304
+    },
+    "/boot/efi": {
+      "available": "186.83 MiB",
+      "available_bytes": 195907584,
+      "capacity": "6.47%",
+      "device": "/dev/sda2",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "199.77 MiB",
+      "size_bytes": 209469440,
+      "used": "12.93 MiB",
+      "used_bytes": 13561856
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=117901",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "477.53 MiB",
+      "available_bytes": 500723712,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "477.53 MiB",
+      "size_bytes": 500723712,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "187.44 MiB",
+      "available_bytes": 196546560,
+      "capacity": "1.87%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=195596k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "191.01 MiB",
+      "size_bytes": 200290304,
+      "used": "3.57 MiB",
+      "used_bytes": 3743744
+    },
+    "/run/credentials/getty@tty1.service": {
+      "available": "1.00 MiB",
+      "available_bytes": 1048576,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "nosymfollow",
+        "size=1024k",
+        "nr_inodes=1024",
+        "mode=700",
+        "inode64",
+        "noswap"
+      ],
+      "size": "1.00 MiB",
+      "size_bytes": 1048576,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/serial-getty@ttyS0.service": {
+      "available": "1.00 MiB",
+      "available_bytes": 1048576,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "nosymfollow",
+        "size=1024k",
+        "nr_inodes=1024",
+        "mode=700",
+        "inode64",
+        "noswap"
+      ],
+      "size": "1.00 MiB",
+      "size_bytes": 1048576,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-journald.service": {
+      "available": "1.00 MiB",
+      "available_bytes": 1048576,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "nosymfollow",
+        "size=1024k",
+        "nr_inodes=1024",
+        "mode=700",
+        "inode64",
+        "noswap"
+      ],
+      "size": "1.00 MiB",
+      "size_bytes": 1048576,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "95.50 MiB",
+      "available_bytes": 100134912,
+      "capacity": "0.01%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=97796k",
+        "nr_inodes=24449",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "95.50 MiB",
+      "size_bytes": 100143104,
+      "used": "8.00 KiB",
+      "used_bytes": 8192
+    },
+    "/vagrant": {
+      "available": "318.33 GiB",
+      "available_bytes": 341807607808,
+      "capacity": "65.00%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "909.41 GiB",
+      "size_bytes": 976476184576,
+      "used": "591.08 GiB",
+      "used_bytes": 634668576768
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "enp0s3": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd17:625c:f037:2:68ae:6fd4:3d05:c6f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd17:625c:f037:2::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::34f1:2a32:96df:f711",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd17:625c:f037:2:68ae:6fd4:3d05:c6f0",
+        "mac": "00:16:3e:55:3b:5a",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd17:625c:f037:2::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd17:625c:f037:2:68ae:6fd4:3d05:c6f0",
+    "mac": "00:16:3e:55:3b:5a",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd17:625c:f037:2::",
+    "primary": "enp0s3",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Coughlan",
+      "description": "Red Hat Enterprise Linux release 10.0 (Coughlan)",
+      "id": "RedHatEnterprise",
+      "release": {
+        "full": "10.0",
+        "major": "10",
+        "minor": "0"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "RedHat",
+    "release": {
+      "full": "10.0",
+      "major": "10",
+      "minor": "0"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "partlabel": "p.legacy",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "6daa36a1-8e8e-4d75-949d-f0eb8de6bf26",
+      "size": "2.00 MiB",
+      "size_bytes": 2097152
+    },
+    "/dev/sda2": {
+      "filesystem": "vfat",
+      "label": "EFI",
+      "mount": "/boot/efi",
+      "partlabel": "p.UEFI",
+      "parttype": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+      "partuuid": "e8295f80-98ea-49d6-9777-a68d641dbeff",
+      "size": "200.00 MiB",
+      "size_bytes": 209715200,
+      "uuid": "2748-9ED0"
+    },
+    "/dev/sda3": {
+      "filesystem": "xfs",
+      "label": "BOOT",
+      "mount": "/boot",
+      "partlabel": "p.lxboot",
+      "parttype": "bc13c2ff-59e6-4262-a352-b275fd6f7172",
+      "partuuid": "bb59c910-6af4-4d1f-9411-1ef9cb28a84e",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "2bc41119-4269-48e3-9bd2-16691e849bf9"
+    },
+    "/dev/sda4": {
+      "filesystem": "xfs",
+      "label": "rhel",
+      "mount": "/",
+      "partlabel": "p.lxroot",
+      "parttype": "4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
+      "partuuid": "0e5893ab-d171-4b09-80d2-fe6c3cb4e0d2",
+      "size": "8.83 GiB",
+      "size_bytes": 9475964416,
+      "uuid": "466e59b7-363a-4ff4-bfbb-24b064cd1e7b"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "unknown"
+    ],
+    "isa": "unknown",
+    "models": [
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "3.99 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.23.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.9"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 d876cad40cad612e5110ee5e09f0cfa45dca6dee",
+        "sha256": "SSHFP 3 2 a139a8e35be9e248595764658aeb000e6761f75942f72664f944ce4456dd1ab3"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG7KnRbJzAjTi2yJmIs8x0Lt+7/F4gi1RcsbkVDHoG5sb7jgT/NhATgv6HRgBhEd7kl9QUkMZ3u4KRuNwJJLx4Q=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 f4b0b6869f7aaa161aa3d7980db2b773202ebdcb",
+        "sha256": "SSHFP 4 2 47f4663ac537f71bbe31cdd4d43072e444b749664a98c32e2c5884603c4e4a29"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIDkV+opGDVkLHDcbeamC3MSRKCzaMg2PB23xpaQo1uxp",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a823d0b44a22648b46e83fd42c6028ae8cba9a0d",
+        "sha256": "SSHFP 1 2 ac233a0b7a14c3938c971633706b42db2da05390356113fdfcc202f5fde21dc5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCPeaGa+8SwdHEF+VOFfTs8JdaSrmpTdjsOL5N7di3WxzA5XkPYDpPzCZi5RlhWNIjaXT9XaNUK+O2sjLWA67Gp+POKnkroauLbv7w31zjcxp9/BmolIyFe0WDIn+e3kx6CLZXOhtPbNIfzCb/jkW9piwDAO8NexnG1bXEYcRf65R0qvuk8sztxq3mUICaquFisuC62wYQGcqf+GzGv7bnX5oszjSxCZtPQIYuxQn0AczBKZW4+ZIiSlHhXqP8AY3hMkuXYXWaNGagWJw5/Yh1Ls95G4nkMQJZlvLERQj/rea2KXTGibL2DnwW2s+FdR5i/iLRgM0FzmbxQnR/qXpZzchrhXrhkRBDWyC+AfS2Fue1DXPTEvQUZUK6x//BNZgiIn09E4myKnsFsIybCW0pK/tL3v97SMEv0s0YL53QLIeqr8gaRbeqbSl82dJ2RiA5Og40D9Ccq/F40cHlnf1TeBCryLHDElW80NfJY1qmJfTJWg27StVjdk2ShgqBo0c0=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 29,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/lib/abide_dev_utils/version.rb
+++ b/lib/abide_dev_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AbideDevUtils
-  VERSION = "0.18.5"
+  VERSION = "0.18.6"
 end


### PR DESCRIPTION
Add a FacterDB fact set for RedHat 10 x86_64 to extend spec test coverage to the new platform.

Also add CLAUDE.md with project guidance for Claude Code and docs/ARCHITECTURE.md with a full breakdown of the repo layout. The Architecture section in CLAUDE.md now defers to that file rather than duplicating the detail inline.

Bump version from 0.18.5 to 0.18.6.